### PR TITLE
Add `deps` action to harmonize dependencies

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,6 +9,7 @@ History
 
 ## Unreleased
 
+* Add `-q` flag.
 * Add `lank deps` action.
 
 ## 0.1.0

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,6 +7,10 @@ History
 * XXX
 -->
 
+## Unreleased
+
+* Add `lank deps` action.
+
 ## 0.1.0
 
 * Add `lank exec` action.

--- a/README.md
+++ b/README.md
@@ -336,6 +336,26 @@ indicate which project the output came from. For example:
 $ lank exec -u -- npm run watch-files
 ```
 
+### Keeping Package Dependencies in Sync
+
+Multiple repositories generally ends up with dependency skews across projects.
+`lank` provides a very convenient manner of harmonizing dependencies across all
+linked projects with:
+
+```sh
+$ lank deps -d  # Check with a dry run first.
+$ lank deps
+```
+
+`lank` uses a simplistic algorithm of:
+
+1. Only looking at deps that are of the forms `1.2.3`, `~1.2.3`, and `^1.2.3`
+2. If 2+ different versions exist in a `package.json`, `lank` chooses the latest
+   or highest version string to win.
+
+`lank` then writes out updates to actual project `package.json` files where
+applicable.
+
 ## Notes, Tips, and Tricks
 
 ### Miscellaneous

--- a/README.md
+++ b/README.md
@@ -356,6 +356,21 @@ $ lank deps
 `lank` then writes out updates to actual project `package.json` files where
 applicable.
 
+For a usual workflow, you'll want to update deps in linked projects, re-install
+dependencies (and new ones), then re-link the projects. Something like:
+
+```sh
+# Update
+$ lank deps
+
+# Reinstall
+$ lank exec -s -- yarn install --force
+$ lank exec -s -- npm install
+
+# Re-link
+$ lank link
+```
+
 ## Notes, Tips, and Tricks
 
 ### Miscellaneous

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -2,8 +2,10 @@
 
 const link = require("./actions/link");
 const exec = require("./actions/exec");
+const deps = require("./actions/deps");
 
 module.exports = {
   link,
-  exec
+  exec,
+  deps
 };

--- a/lib/actions/deps.js
+++ b/lib/actions/deps.js
@@ -19,6 +19,18 @@ const getLog = (fmt) => (msg) => {
   util._stdoutWrite(`${fmt({ color: "gray", key: "deps", msg })}\n`);
 };
 
+// Update dependencies, if in map
+const updateDeps = (depsObj, updateMap) => {
+  if (!depsObj) { return null; }
+
+  const updatedObj = Object.assign({}, depsObj);
+  Object.keys(updatedObj).forEach((key) => {
+    updatedObj[key] = updateMap[key] ? updateMap[key].winner : updatedObj[key];
+  });
+
+  return updatedObj;
+};
+
 // Create mega versions map.
 const getDepsMap = (pkgs) => {
   // Create map of all dependencies.
@@ -110,23 +122,10 @@ module.exports = (cfg, args) => {
 
       // Mutate original packages.
       const updatedPkgs = pkgs.map((pkg) => {
-        const dependencies = pkg.dependencies ? Object.assign({}, pkg.dependencies) : null;
-        if (dependencies) {
-          Object.keys(dependencies).forEach((key) => {
-            dependencies[key] = depsMap[key] ? depsMap[key].winner : dependencies[key];
-          });
-        }
+        const dependencies = updateDeps(pkg.dependencies, depsMap);
+        const devDependencies = updateDeps(pkg.devDependencies, depsMap);
 
-        const devDependencies = pkg.devDependencies ? Object.assign({}, pkg.devDependencies) : null;
-        if (devDependencies) {
-          Object.keys(devDependencies).forEach((key) => {
-            devDependencies[key] = depsMap[key] ? depsMap[key].winner : devDependencies[key];
-          });
-        }
-
-        return Object.assign(
-          {},
-          pkg,
+        return Object.assign({}, pkg,
           dependencies ? { dependencies } : {},
           devDependencies ? { devDependencies } : {}
         );

--- a/lib/actions/deps.js
+++ b/lib/actions/deps.js
@@ -41,7 +41,7 @@ const getDepsMap = (pkgs) => {
       toPairs(pkg.devDependencies || {})
     ))
     // Flatten
-    .reduce((acc, arr) => [].concat(acc, arr), [])
+    .reduce((acc, arr) => acc.concat(arr), [])
     // Accumulate into mega object.
     .reduce((acc, dep) => {
       // Start object with name.

--- a/lib/actions/deps.js
+++ b/lib/actions/deps.js
@@ -57,7 +57,9 @@ const allDeps = (pkgs) => {
         prev.replace(/^[\^\~]/, ""),
         cur.replace(/^[\^\~]/, "")
       ) ? prev : cur, null)
-    }, dep));
+    }, dep))
+    // ... and back to object!
+    .reduce((acc, dep) => Object.assign({ [dep.name]: dep }, acc), {});
 
   return filteredDepsMap;
 };
@@ -84,7 +86,13 @@ module.exports = (cfg, args) => {
     // Convert to mega object
     .then(allDeps)
     .then((depMap) => {
-      log(`Found ${Object.keys(depMap).length} dependencies to harmonize:`);
+      const keys = Object.keys(depMap);
+      log(`Found ${keys.length} dependencies to harmonize:`);
+      keys.forEach((key) => {
+        const dep = depMap[key];
+        const versions = dep.versions.map((v) => chalk.gray(v)).join(", ");
+        log(`- ${chalk.cyan(key)}: ${chalk.red(dep.winner)} (${versions})`);
+      });
 
       if (isDryRun) {
         log(chalk.yellow("Dry run - skipping package.json updates"));

--- a/lib/actions/deps.js
+++ b/lib/actions/deps.js
@@ -5,6 +5,7 @@ const fs = require("fs-extra");
 const path = require("path");
 const pify = require("pify");
 const readJson = pify(fs.readJson);
+const writeJson = pify(fs.writeJson);
 const semver = require("semver");
 
 const util = require("../util");
@@ -18,8 +19,8 @@ const getLog = (fmt) => (msg) => {
   util._stdoutWrite(`${fmt({ color: "gray", key: "deps", msg })}\n`);
 };
 
-// Create mega versions object.
-const allDeps = (pkgs) => {
+// Create mega versions map.
+const getDepsMap = (pkgs) => {
   // Create map of all dependencies.
   const allDepsMap = pkgs
     // Convert to array of combine prod/dev deps
@@ -82,14 +83,22 @@ module.exports = (cfg, args) => {
     path.join(util._cwd(), util.getSiblingPath(cfg), obj.module, "package.json")
   ));
 
+  // Write packages out.
+  const writePkgs = (pkgs) => pkgs.map((pkg) => writeJson(
+    path.join(util._cwd(), util.getSiblingPath(cfg), pkg.name, "package.json"),
+    pkg,
+    { spaces: 2 }
+  ));
+
   return Promise.all(getPkgs)
-    // Convert to mega object
-    .then(allDeps)
-    .then((depMap) => {
-      const keys = Object.keys(depMap);
+    .then((pkgs) => {
+      // Convert to map.
+      const depsMap = getDepsMap(pkgs);
+      const keys = Object.keys(depsMap);
+
       log(`Found ${keys.length} dependencies to harmonize:`);
       keys.forEach((key) => {
-        const dep = depMap[key];
+        const dep = depsMap[key];
         const versions = dep.versions.map((v) => chalk.gray(v)).join(", ");
         log(`- ${chalk.cyan(key)}: ${chalk.red(dep.winner)} (${versions})`);
       });
@@ -99,8 +108,32 @@ module.exports = (cfg, args) => {
         return Promise.resolve();
       }
 
+      // Mutate original packages.
+      const updatedPkgs = pkgs.map((pkg) => {
+        const dependencies = pkg.dependencies ? Object.assign({}, pkg.dependencies) : null;
+        if (dependencies) {
+          Object.keys(dependencies).forEach((key) => {
+            dependencies[key] = depsMap[key] ? depsMap[key].winner : dependencies[key];
+          });
+        }
+
+        const devDependencies = pkg.devDependencies ? Object.assign({}, pkg.devDependencies) : null;
+        if (devDependencies) {
+          Object.keys(devDependencies).forEach((key) => {
+            devDependencies[key] = depsMap[key] ? depsMap[key].winner : devDependencies[key];
+          });
+        }
+
+        return Object.assign(
+          {},
+          pkg,
+          dependencies ? { dependencies } : {},
+          devDependencies ? { devDependencies } : {}
+        );
+      });
+
       log(chalk.yellow("Updating package.json files"));
-      return Promise.resolve(); // TODO: IMPLEMENT
+      return Promise.all(writePkgs(updatedPkgs));
     });
 };
 

--- a/lib/actions/deps.js
+++ b/lib/actions/deps.js
@@ -87,7 +87,7 @@ const getDepsMap = (pkgs) => {
  * @return {Promise}      promise wrapping all changes
  */
 module.exports = (cfg, args) => {
-  const log = getLog(getFmt(cfg));
+  const log = args.quiet ? () => {} : getLog(getFmt(cfg));
   const isDryRun = args.dryRun;
 
   // Get all project package.json files.

--- a/lib/actions/deps.js
+++ b/lib/actions/deps.js
@@ -66,10 +66,27 @@ const getDepsMap = (pkgs) => {
     // Add "winning" version
     .map((dep) => Object.assign({
       // Take greatest version after ignoring prefix ^~ chars.
-      winner: dep.versions.reduce((prev, cur) => prev && semver.gt(
-        prev.replace(/^[\^\~]/, ""),
-        cur.replace(/^[\^\~]/, "")
-      ) ? prev : cur, null)
+      winner: dep.versions.reduce((prev, cur) => {
+        if (!prev) { return cur; }
+
+        // Strip prefixes.
+        const prevNum = prev.replace(/^[\^\~]/, "");
+        const curNum = cur.replace(/^[\^\~]/, "");
+
+        // If identical numbers, then choose >, then ~, then nothing.
+        if (prevNum === curNum) {
+          if (/^\^/.test(prev)) { return prev; }
+          if (/^\^/.test(cur)) { return cur; }
+          if (/^\~/.test(prev)) { return prev; }
+          if (/^\~/.test(cur)) { return cur; }
+
+          // Identical *and* pinned.
+          return prev;
+        }
+
+        // Semver diff.
+        return semver.gt(prevNum, curNum) ? prev : cur;
+      }, null)
     }, dep))
     // ... and back to object!
     .reduce((acc, dep) => Object.assign({ [dep.name]: dep }, acc), {});

--- a/lib/actions/deps.js
+++ b/lib/actions/deps.js
@@ -1,0 +1,99 @@
+"use strict";
+
+const chalk = require("chalk");
+const fs = require("fs-extra");
+const path = require("path");
+const pify = require("pify");
+const readJson = pify(fs.readJson);
+const semver = require("semver");
+
+const util = require("../util");
+const getFmt = util.getFmt;
+
+// Helper to convert object to pairs of `[k, v]`
+const toPairs = (obj) => Object.keys(obj).map((name) => ({ name, version: obj[name] }));
+
+// Simple log helper
+const getLog = (fmt) => (msg) => {
+  util._stdoutWrite(`${fmt({ color: "gray", key: "deps", msg })}\n`);
+};
+
+// Create mega versions object.
+const allDeps = (pkgs) => {
+  // Create map of all dependencies.
+  const allDepsMap = pkgs
+    // Convert to array of combine prod/dev deps
+    .map((pkg) => [].concat(
+      toPairs(pkg.dependencies || {}),
+      toPairs(pkg.devDependencies || {})
+    ))
+    // Flatten
+    .reduce((acc, arr) => [].concat(acc, arr), [])
+    // Accumulate into mega object.
+    .reduce((acc, dep) => {
+      // Start object with name.
+      acc[dep.name] = acc[dep.name] || { name: dep.name };
+      // Create set for efficient unique value storage. (Will convert to array later).
+      acc[dep.name].versions = (acc[dep.name].versions || new Set()).add(dep.version);
+
+      return acc;
+    }, {});
+
+  // Filter to things we need to actually change.
+  const filteredDepsMap = Object.keys(allDepsMap)
+    // Start by switching back to array of objects for filtering and swapping sets to arrays.
+    .map((name) => ({
+      name: allDepsMap[name].name,
+      versions: Array.from(allDepsMap[name].versions)
+    }))
+    // Remove version single deps or all identical versions
+    .filter((dep) => dep.versions.length > 1)
+    // Handle only "easy" subset of dependencies: Those starting with `^~` or nothing.
+    .filter((dep) => dep.versions.every((version) => /^[\^\~0-9]/.test(version)))
+    // Add "winning" version
+    .map((dep) => Object.assign({
+      // Take greatest version after ignoring prefix ^~ chars.
+      winner: dep.versions.reduce((prev, cur) => prev && semver.gt(
+        prev.replace(/^[\^\~]/, ""),
+        cur.replace(/^[\^\~]/, "")
+      ) ? prev : cur, null)
+    }, dep));
+
+  return filteredDepsMap;
+};
+
+/**
+ * Harmonize all deps found in 2+ projects to latest semver-version.
+ *
+ * Write updated `package.json` files in all projects
+ *
+ * @param {Object}  cfg   configuration
+ * @param {Object}  args  arguments
+ * @return {Promise}      promise wrapping all changes
+ */
+module.exports = (cfg, args) => {
+  const log = getLog(getFmt(cfg));
+  const isDryRun = args.dryRun;
+
+  // Get all project package.json files.
+  const getPkgs = cfg.projs.map((obj) => readJson(
+    path.join(util._cwd(), util.getSiblingPath(cfg), obj.module, "package.json")
+  ));
+
+  return Promise.all(getPkgs)
+    // Convert to mega object
+    .then(allDeps)
+    .then((depMap) => {
+      log(`Found ${Object.keys(depMap).length} dependencies to harmonize:`);
+
+      if (isDryRun) {
+        log(chalk.yellow("Dry run - skipping package.json updates"));
+        return Promise.resolve();
+      }
+
+      log(chalk.yellow("Updating package.json files"));
+      return Promise.resolve(); // TODO: IMPLEMENT
+    });
+};
+
+module.exports.description = "Harmonize / update dependencies in all project package.json files";

--- a/lib/actions/exec.js
+++ b/lib/actions/exec.js
@@ -22,6 +22,7 @@ module.exports = (cfg, args) => {
   }, {
     cfg,
     proj: obj.module,
+    quiet: args.quiet,
     unbuffered: args.unbuffered,
     dryRun: args.dryRun
   }));

--- a/lib/actions/link.js
+++ b/lib/actions/link.js
@@ -76,7 +76,7 @@ const getLog = (fmt) => (msg) => {
  * @return {Promise}      promise wrapping all executions
  */
 module.exports = (cfg, args) => {
-  const log = getLog(getFmt(cfg));
+  const log = args.quiet ? () => {} : getLog(getFmt(cfg));
   const isDryRun = args.dryRun;
   const projs = cfg.projs;
 

--- a/lib/args.js
+++ b/lib/args.js
@@ -53,6 +53,7 @@ const parseToArgs = (program, argv) => {
     .option("-m, --modules <modules>", "Comma-delimited modules to filter commands to", toList)
     .option("-d, --dry-run", "Display action to do without")
     .option("-s, --series", "Run actions sequentially, not in parallel")
+    .option("-q, --quiet", "No additional lank output. Pass through existing stdout/stderr.")
     .option("-u, --unbuffered", "Don't buffer + save output, immediately display");
 
   // Add in actions as commands.
@@ -114,6 +115,7 @@ module.exports.parse = (argv) => {
     mods: args.parsed.modules || [],
     dryRun: !!args.parsed.dryRun,
     series: !!args.parsed.series,
+    quiet: !!args.parsed.quiet,
     unbuffered: !!args.parsed.unbuffered,
     extra: args.extra
   };

--- a/lib/util.js
+++ b/lib/util.js
@@ -115,7 +115,7 @@ const util = module.exports = {
 
     // Get formatter, wrappers.
     const fmt = util.getFmt(opts.cfg);
-    const writeMsg = opts.quiet ? noop : (msg) => {
+    const writeMsg = isQuiet ? noop : (msg) => {
       const write = msg.key === "stderr" ? util._stderrWrite : util._stdoutWrite;
       write(`${fmt(msg)}${os.EOL}`);
     };

--- a/lib/util.js
+++ b/lib/util.js
@@ -91,6 +91,8 @@ const util = module.exports = {
   // eslint-disable-next-line promise/avoid-new,max-statements
   exec: (cmd, shellOpts, opts) => new Promise((resolve, reject) => {
     opts = opts || {};
+    const isDryRun = opts.dryRun;
+    const isQuiet = opts.quiet;
 
     // Validate.
     if (!opts.cfg) {
@@ -98,10 +100,9 @@ const util = module.exports = {
     }
 
     // Infer and mutate shell options.
-    const isDryRun = opts.dryRun;
     const args = createCmd(cmd, shellOpts);
     shellOpts = Object.assign({
-      stdio: "pipe",
+      stdio: isQuiet ? "inherit" : "pipe",
       env: Object.assign({}, process.env)
     }, args.shellOpts);
 
@@ -114,7 +115,7 @@ const util = module.exports = {
 
     // Get formatter, wrappers.
     const fmt = util.getFmt(opts.cfg);
-    const writeMsg = (msg) => {
+    const writeMsg = opts.quiet ? noop : (msg) => {
       const write = msg.key === "stderr" ? util._stderrWrite : util._stdoutWrite;
       write(`${fmt(msg)}${os.EOL}`);
     };
@@ -141,16 +142,18 @@ const util = module.exports = {
       [];
 
     // Start handlers and messaging.
-    proc.stdout.on("data", (data) => {
-      buffer.push({
-        color: "green", proj: opts.proj, key: "stdout", msg: data.toString()
+    if (!isQuiet) {
+      proc.stdout.on("data", (data) => {
+        buffer.push({
+          color: "green", proj: opts.proj, key: "stdout", msg: data.toString()
+        });
       });
-    });
-    proc.stderr.on("data", (data) => {
-      buffer.push({
-        color: "red", proj: opts.proj, key: "stderr", msg: data.toString()
+      proc.stderr.on("data", (data) => {
+        buffer.push({
+          color: "red", proj: opts.proj, key: "stderr", msg: data.toString()
+        });
       });
-    });
+    }
 
     proc.on("close", (code) => {
       // Drain buffers to formatted output.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "chalk": "^1.1.3",
     "commander": "^2.9.0",
     "fs-extra": "^2.1.2",
-    "pify": "^2.3.0"
+    "pify": "^2.3.0",
+    "semver": "^5.3.0"
   },
   "devDependencies": {
     "babel-eslint": "^7.1.1",

--- a/test/server/spec/base.spec.js
+++ b/test/server/spec/base.spec.js
@@ -27,6 +27,7 @@ const base = module.exports = {
   // File stuff
   // NOTE: Sync methods are OK here because mocked and in-memory.
   fileRead: (filePath, encoding) => fs.readFileSync(filePath).toString(encoding),
+  fileJson: (filePath) => fs.readJsonSync(filePath),
   fileExists: (filePath) => fs.existsSync(filePath)
 };
 

--- a/test/server/spec/bin/lank.spec.js
+++ b/test/server/spec/bin/lank.spec.js
@@ -393,7 +393,52 @@ describe("bin/lank", () => {
   });
 
   describe("deps", () => {
-    it("TODO: handles empty package.json files");
+    let pkgOne;
+    let pkgTwo;
+    let getFs;
+
+    beforeEach(() => {
+      pkgOne = {
+        name: "one",
+        dependencies: {},
+        devDependencies: {}
+      };
+      pkgTwo = {
+        name: "two",
+        dependencies: {},
+        devDependencies: {}
+      };
+
+      getFs = () => ({
+        ".lankrc.js": toJs({
+          one: { tags: ["awesome", "hot"] },
+          two: { tags: ["awesome"] }
+        }),
+        "one": {
+          "package.json": JSON.stringify(pkgOne),
+          "node_modules": {}
+        },
+        "two": {
+          "package.json": JSON.stringify(pkgTwo)
+        }
+      });
+    });
+
+    it("handles empty package.json files", () => {
+      pkgOne = {
+        name: "one"
+      };
+
+      base.mockFs(getFs());
+
+      return lank(argv("deps"))
+        .then(() => {
+          expect(appUtil._stdoutWrite).to.be.calledWithMatch("Found 0 dependencies");
+          expect(base.fileJson("one/package.json")).to.eql(pkgOne);
+          expect(base.fileJson("two/package.json")).to.eql(pkgTwo);
+        });
+    });
+
     it("TODO: leaves unchanged deps unchanged");
     it("TODO: updates deps");
     it("TODO: updates deps with mixed ~^ and nothing");

--- a/test/server/spec/bin/lank.spec.js
+++ b/test/server/spec/bin/lank.spec.js
@@ -392,4 +392,12 @@ describe("bin/lank", () => {
     it("TODO: limits to modules");
   });
 
+  describe("deps", () => {
+    it("TODO: handles empty package.json files");
+    it("TODO: leaves unchanged deps unchanged");
+    it("TODO: updates deps");
+    it("TODO: updates deps with mixed ~^ and nothing");
+    it("TODO: updates devDeps");
+  });
+
 });


### PR DESCRIPTION
- Adds `lank deps`, which harmonizes to "greatest" dependency and updates all package.json files across projects.
- Add documentation of limitations.
- Add `-q` flag and enable inherited output for `exec`

Sample usage in victory:

```js
// .lankrc.js`
module.exports = {
  "victory": { tags: ["web"] },
  "victory-native": { tags: ["native"] },
  "victory-core": { tags: "web" },
  "victory-pie": { tags: ["web"] },
  "victory-chart": { tags: ["web"] },
  "builder-victory-component": { tags: ["build"] },
  "builder-victory-component-dev": { tags: ["build"] }
};
```

Let's harmonize all of the deps in `web,build` projects:

```sh
# First a dry run...
$ lank deps -t web,build -d
[lank:deps]                                 Found 8 dependencies to harmonize:
[lank:deps]                                 - sinon: ^1.17.5 (^1.17.2, ^1.15.4, ^1.17.5)
[lank:deps]                                 - react-dom: ~15.1.0 (^15.1.0, ~15.1.0)
[lank:deps]                                 - react-addons-test-utils: ~15.1.0 (^15.1.0, ~15.1.0)
[lank:deps]                                 - react: ~15.1.0 (^15.1.0, ~15.1.0)
[lank:deps]                                 - mocha: ^3.0.2 (^2.3.3, ^2.2.5, ^3.0.2)
[lank:deps]                                 - lodash: ^4.15.0 (^4.12.0, ^4.15.0)
[lank:deps]                                 - victory-core: ^14.1.1 (^14.1.0, ^14.0.7, ^14.1.1)
[lank:deps]                                 - builder: ^3.2.1 (^3.1.0, ^3.2.1)
[lank:deps]                                 Dry run - skipping package.json updates
[lank:main]                                 Done.

# Now for real...
$ lank deps -t web,build
```

Now let's check the diff in each repro using unbuffered (`u`), serial (`s`), and quiet (`q`) output to **just** get the process output.

```diff
$ lank exec -t web,build -u -q -s -- 'echo \\n\# $(pwd) && git diff'

# /Users/rye/scm/fmd/victory
diff --git a/package.json b/package.json
index e6d9b01..fa64f4f 100644
--- a/package.json
+++ b/package.json
@@ -32,21 +32,21 @@
     "version": "builder run npm:version"
   },
   "dependencies": {
-    "builder": "^3.1.0",
+    "builder": "^3.2.1",
     "builder-victory-component": "^3.1.0",
     "victory-chart": "^18.2.0",
-    "victory-core": "^14.1.0",
+    "victory-core": "^14.1.1",
     "victory-pie": "^10.3.0"
   },
   "devDependencies": {
     "builder-victory-component-dev": "^3.1.0",
     "chai": "^3.2.0",
-    "lodash": "^4.12.0",
-    "mocha": "^2.3.3",
-    "react": "^15.1.0",
-    "react-addons-test-utils": "^15.1.0",
-    "react-dom": "^15.1.0",
-    "sinon": "^1.17.2",
+    "lodash": "^4.15.0",
+    "mocha": "^3.0.2",
+    "react": "~15.1.0",
+    "react-addons-test-utils": "~15.1.0",
+    "react-dom": "~15.1.0",
+    "sinon": "^1.17.5",
     "sinon-chai": "^2.8.0"
   },
   "publishr": {

# /Users/rye/scm/fmd/victory-core
diff --git a/package.json b/package.json
index 0d9084a..d63f8a2 100644
--- a/package.json
+++ b/package.json
@@ -26,25 +26,25 @@
     "version": "builder run npm:version"
   },
   "dependencies": {
-    "builder": "^3.1.0",
+    "builder": "^3.2.1",
     "builder-victory-component": "^3.1.0",
     "d3-ease": "^1.0.0",
     "d3-interpolate": "^1.1.1",
     "d3-scale": "^1.0.0",
     "d3-shape": "^1.0.0",
     "d3-timer": "^1.0.0",
-    "lodash": "^4.12.0"
+    "lodash": "^4.15.0"
   },
   "devDependencies": {
     "builder-victory-component-dev": "^3.1.0",
     "chai": "^3.2.0",
     "enzyme": "^2.3.0",
-    "mocha": "^2.2.5",
+    "mocha": "^3.0.2",
     "react": "~15.1.0",
     "react-addons-test-utils": "~15.1.0",
     "react-dom": "~15.1.0",
     "react-router": "^2.4.0",
-    "sinon": "^1.17.2",
+    "sinon": "^1.17.5",
     "sinon-chai": "^2.8.0"
   },
   "publishr": {

# /Users/rye/scm/fmd/victory-pie
diff --git a/package.json b/package.json
index be479f9..f550e55 100644
--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "builder": "^3.2.1",
     "builder-victory-component": "^3.1.0",
     "d3-shape": "^1.0.0",
-    "lodash": "^4.12.0",
-    "victory-core": "^14.0.7"
+    "lodash": "^4.15.0",
+    "victory-core": "^14.1.1"
   },
   "devDependencies": {
     "@kadira/storybook": "^1.25.0",
@@ -39,12 +39,12 @@
     "chai": "^3.2.0",
     "chai-enzyme": "0.4.1",
     "enzyme": "^2.3.0",
-    "mocha": "^2.2.5",
+    "mocha": "^3.0.2",
     "react": "~15.1.0",
     "react-addons-test-utils": "~15.1.0",
     "react-dom": "~15.1.0",
     "react-router": "^2.4.0",
-    "sinon": "^1.15.4",
+    "sinon": "^1.17.5",
     "sinon-chai": "^2.8.0"
   },
   "publishr": {

# /Users/rye/scm/fmd/victory-chart
diff --git a/package.json b/package.json
index fc2c066..c0d19a4 100644
--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
     "version": "builder run npm:version"
   },
   "dependencies": {
-    "builder": "^3.1.0",
+    "builder": "^3.2.1",
     "builder-victory-component": "^3.1.0",
     "d3-voronoi": "^1.1.2",
-    "lodash": "^4.12.0",
+    "lodash": "^4.15.0",
     "victory-core": "^14.1.1"
   },
   "devDependencies": {
@@ -39,12 +39,12 @@
     "d3-scale": "^1.0.0",
     "d3-shape": "^1.0.0",
     "enzyme": "^2.3.0",
-    "mocha": "^2.2.5",
+    "mocha": "^3.0.2",
     "react": "~15.1.0",
     "react-addons-test-utils": "~15.1.0",
     "react-dom": "~15.1.0",
     "react-router": "^2.4.0",
-    "sinon": "^1.17.2",
+    "sinon": "^1.17.5",
     "sinon-chai": "^2.8.0"
   },
   "publishr": {

# /Users/rye/scm/fmd/builder-victory-component

# /Users/rye/scm/fmd/builder-victory-component-dev
```

/cc @boygirl @chrisbolin